### PR TITLE
Remove space causing error.

### DIFF
--- a/doc_source/WorkingWithTables.Basics.md
+++ b/doc_source/WorkingWithTables.Basics.md
@@ -31,8 +31,7 @@ aws dynamodb create-table \
         AttributeName=Artist,KeyType=HASH \
         AttributeName=SongTitle,KeyType=RANGE \
     --provisioned-throughput \
-        ReadCapacityUnits=10, \
-        WriteCapacityUnits=5
+        ReadCapacityUnits=10,WriteCapacityUnits=5
 ```
 
 The `CreateTable` operation returns metadata for the table, as shown below:


### PR DESCRIPTION
When I ran the sample of create-table it threw an error. After researching there was a space between ReadCapacityUnites=10, and WriteCapacityUnites=5. I removed the space and the create-table is working now. This Pull Request matches the documentation for the same example (that works) from this page: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.CLI.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
