### PR TITLE
Update GSI.md

### DIFF
--- a/doc_source/GSI.md
+++ b/doc_source/GSI.md
@@ -81,12 +81,6 @@ When you create a secondary index, you need to specify the attributes that will 
 
 + *ALL* – The secondary index includes all of the attributes from the source table\. Because all of the table data is duplicated in the index, an `ALL` projection results in the largest possible secondary index\.
 
-In the diagram above, *GameTitleIndex* does not have any additional projected attributes\. An application can use *GameTitle* and *TopScore* in queries; however, it is not possible to efficiently determine which user has the highest score for a particular game, or the highest ratio of wins vs\. losses\. The most efficient way to support queries on this data would be to project these attributes from the base table into the global secondary index, as shown in this diagram:
-
-![\[Image NOT FOUND\]](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/)![\[Image NOT FOUND\]](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/)![\[Image NOT FOUND\]](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/)
-
-Because the non\-key attributes Wins and Losses are projected into the index, an application can determine the wins vs\. losses ratio for any game, or for any combination of game and user ID\.
-
 When you choose the attributes to project into a global secondary index, you must consider the tradeoff between provisioned throughput costs and storage costs:
 
 + If you need to access just a few attributes with the lowest possible latency, consider projecting only those attributes into a global secondary index\. The smaller the index, the less that it will cost to store it, and the less your write costs will be\.


### PR DESCRIPTION
Removed bad example of additional projected attributes. This deleted example is both confusing and confused.

Confusing: it refers back to a version of GameTitleIndex that does not have the UserId attribute projected into it. No such version exists.

Confused: Projecting the Wins and Losses attributes into GameTitleIndex does not make querying for highest ratio of wins to losses efficient because Wins are Losses are not part of the sort key. To get that ratio, you have to scan the entire index (or at least all entries for a particular game) and do the calculations manually. This could be done just as efficiently on the base table itself.

The only benefit of projecting Wins and Losses is the ability is to *display* those attributes along side the top scorer without needing to go back and do an additional Query on the base table. Or, the ability to display the list of top scorers for a particular game sorted by win/loss percentage (doing the calculation and sorting manually on the small number of top scorers) without having to do the additional Query on the base table.

I guess if the number of attributes in the base table was very large, doing the full scan on an index with only a few attributes is an efficiency in term of provisioned reads, but that's not the gist of the explanation in the text.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
