### PR TITLE
Use DAX Client in DAX example

### DIFF
--- a/doc_source/DAX.client.run-application-nodejs.03-getitem-test.md
+++ b/doc_source/DAX.client.run-application-nodejs.03-getitem-test.md
@@ -20,6 +20,7 @@ if (process.argv.length > 2) {
     daxClient = new AWS.DynamoDB.DocumentClient({service: dax });
 }
 
+var client = daxClient != null ? daxClient : ddbClient;
 var tableName = "TryDaxTable";
 
 var pk = 1;
@@ -41,7 +42,7 @@ for (var i = 0; i < iterations; i++) {
                 }
             };
 
-            ddbClient.get(params, function(err, data) {
+            client.get(params, function(err, data) {
                 if (err) {
                     console.error("Unable to read item. Error JSON:", JSON.stringify(err, null, 2));
                 } else {


### PR DESCRIPTION
The example hard-coded the DDB client instead of switching based on parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
