### PR TITLE
Fix node benchmarking scripts

### DIFF
--- a/doc_source/DAX.client.run-application-nodejs.03-getitem-test.md
+++ b/doc_source/DAX.client.run-application-nodejs.03-getitem-test.md
@@ -26,6 +26,7 @@ var tableName = "TryDaxTable";
 var pk = 1;
 var sk = 10;
 var iterations = 5;
+var promises = [];
 
 for (var i = 0; i < iterations; i++) {
 
@@ -48,12 +49,20 @@ for (var i = 0; i < iterations; i++) {
                 } else {
                     // GetItem succeeded
                 }
+
+                remaining = remaining - 1;
+
+                if(remaining <= 0) {
+                    var endTime = new Date().getTime();
+                    console.log("\tTotal time: ", (endTime - startTime) , "ms - Avg time: ", (endTime - startTime) / iterations, "ms");
+                }
             });
         }
     }
-    
-    var endTime = new Date().getTime();
-    console.log("\tTotal time: ", (endTime - startTime) , "ms - Avg time: ", (endTime - startTime) / iterations, "ms");
 
 }
+
+(function wait () {
+   if (remaining >= 0) setImmediate(wait);
+})();
 ```

--- a/doc_source/DAX.client.run-application-nodejs.04-query-test.md
+++ b/doc_source/DAX.client.run-application-nodejs.04-query-test.md
@@ -26,6 +26,7 @@ var pk = 5;
 var sk1 = 2;
 var sk2 = 9;
 var iterations = 5;
+var remaining = iterations;
 
 var params = {
     TableName: tableName,
@@ -46,10 +47,18 @@ for (var i = 0; i < iterations; i++) {
         } else {
             // Query succeeded
         }
+
+        remaining = remaining - 1;
+
+        if(remaining <= 0) {
+            var endTime = new Date().getTime();
+            console.log("\tTotal time: ", (endTime - startTime) , "ms - Avg time: ", (endTime - startTime) / iterations, "ms");
+        }
     });
 
-    var endTime = new Date().getTime();
-    console.log("\tTotal time: ", (endTime - startTime) , "ms - Avg time: ", (endTime - startTime) / iterations, "ms");
-
 }
+
+(function wait () {
+   if (remaining >= 0) setImmediate(wait);
+})();
 ```

--- a/doc_source/DAX.client.run-application-nodejs.05-scan-test.md
+++ b/doc_source/DAX.client.run-application-nodejs.05-scan-test.md
@@ -22,6 +22,7 @@ if (process.argv.length > 2) {
 var tableName = "TryDaxTable";
 
 var iterations = 5;
+var remaining = iterations;
 
 var params = {
     TableName: tableName
@@ -36,10 +37,18 @@ for (var i = 0; i < iterations; i++) {
         } else {
             // Scan succeeded
         }
+
+        remaining = remaining - 1;
+
+        if(remaining <= 0) {
+            var endTime = new Date().getTime();
+            console.log("\tTotal time: ", (endTime - startTime) , "ms - Avg time: ", (endTime - startTime) / iterations, "ms");
+        }
     });
 
 }
 
-var endTime = new Date().getTime();
-console.log("\tTotal time: ", (endTime - startTime) , "ms - Avg time: ", (endTime - startTime) / iterations, "ms");
+(function wait () {
+   if (remaining >= 0) setImmediate(wait);
+})();
 ```


### PR DESCRIPTION
fixes #2 

The node benchmarking "toy app" currently exits immediately, without actually waiting for the DynamoDB or DAX queries to complete. This PR forces Node to wait until all the network calls are complete before printing the time taken.