### PR TITLE
Fix Typo in Article Description

### DIFF
--- a/doc_source/LowLevelDotNetTableOperationsExample.md
+++ b/doc_source/LowLevelDotNetTableOperationsExample.md
@@ -1,6 +1,6 @@
 # Example: Create, Update, Delete, and List Tables Using the AWS SDK for \.NET Low\-Level API<a name="LowLevelDotNetTableOperationsExample"></a>
 
-The following C\# example create,, updates, and deletes a table \(ExampleTable\)\. It also lists all the tables in your account and gets the description of a specific table\. The table update increases the provisioned throughput values\. For step\-by\-step instructions to test the following sample, see [\.NET Code Samples](CodeSamples.DotNet.md)\. 
+The following C\# example creates, updates, and deletes a table \(ExampleTable\)\. It also lists all the tables in your account and gets the description of a specific table\. The table update increases the provisioned throughput values\. For step\-by\-step instructions to test the following sample, see [\.NET Code Samples](CodeSamples.DotNet.md)\. 
 
 ```
 using System;


### PR DESCRIPTION
In brief description at beginning of `LowLevelDotNetTableOperationsExample.md`, change
`create,,` to `creates,`
which appears to be the intended wording.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
