### PR TITLE
Python example is not compliant for python3

### DIFF
--- a/doc_source/time-to-live-ttl-how-to.md
+++ b/doc_source/time-to-live-ttl-how-to.md
@@ -71,6 +71,6 @@ aws dynamodb put-item --table-name "TTLExample" --item '{"id": {"N": "1"}, "ttl"
 
 It is fairly simple to get the current time in epoch time format\. For example:
 + Linux Terminal: `date +%s`
-+ Python: `import time; long(time.time())`
++ Python: `import time; int(time.time())`
 + Java: `System.currentTimeMillis() / 1000L`
 + JavaScript: `Math.floor(Date.now() / 1000)`


### PR DESCRIPTION
```
>>> import time; long(time.time())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'long' is not defined
```

Swapping long with int is valid python2 and python3 code

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
