### PR TITLE
(fix) Add "Point-in-time Recovery settings" to manual setup after res…

### DIFF
--- a/doc_source/backuprestore_HowItWorks.md
+++ b/doc_source/backuprestore_HowItWorks.md
@@ -28,6 +28,7 @@ You must manually set up the following on the restored table:
 + Tags
 + Stream settings
 + Time To Live \(TTL\) settings
++ Point-in-time Recovery settings
 
 While a backup is in progress, you can't do the following:
 + Pause or cancel the backup operation\.


### PR DESCRIPTION
…tore

Point-in-time Recovery settings are not restored from the backup.

*Description of changes:*
Missing this in the docs can lead to customers not enabling it back when needed,
only to realize it was missing when they need to restore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
