### PR TITLE
Update CodeSamples.md

### DIFF
--- a/doc_source/CodeSamples.md
+++ b/doc_source/CodeSamples.md
@@ -1,12 +1,12 @@
-# Running the Code Samples In This Developer Guide<a name="CodeSamples"></a>
+# Running the Code Examples In This Developer Guide<a name="CodeSamples"></a>
 
-The AWS SDKs provide broad support for DynamoDB in [ Java](https://aws.amazon.com/sdk-for-java), [JavaScript in the browser](https://aws.amazon.com/sdk-for-browser), [\.NET](https://aws.amazon.com/sdk-for-net), [Node\.js](https://aws.amazon.com/sdk-for-node-js), [PHP](https://aws.amazon.com/sdk-for-php), [Python](https://aws.amazon.com/sdk-for-python), [Ruby](https://aws.amazon.com/sdk-for-ruby), [C\+\+](https://aws.amazon.com/sdk-for-cpp), [Go](https://aws.amazon.com/sdk-for-go), [Android](https://aws.amazon.com/mobile/sdk/), and [iOS](https://aws.amazon.com/mobile/sdk/)\. To get started quickly with these languages, see [Getting Started with DynamoDB](GettingStarted.md)\.
+The AWS SDKs provide broad support for Amazon DynamoDB in [ Java](https://aws.amazon.com/sdk-for-java), [JavaScript in the browser](https://aws.amazon.com/sdk-for-browser), [\.NET](https://aws.amazon.com/sdk-for-net), [Node\.js](https://aws.amazon.com/sdk-for-node-js), [PHP](https://aws.amazon.com/sdk-for-php), [Python](https://aws.amazon.com/sdk-for-python), [Ruby](https://aws.amazon.com/sdk-for-ruby), [C\+\+](https://aws.amazon.com/sdk-for-cpp), [Go](https://aws.amazon.com/sdk-for-go), [Android](https://aws.amazon.com/mobile/sdk/), and [iOS](https://aws.amazon.com/mobile/sdk/)\. To get started quickly with these languages, see [Getting Started with DynamoDB](GettingStarted.md)\.
 
-The code samples in this Developer Guide provide more in\-depth coverage of DynamoDB operations, using the following programming languages:
-+ [Java Code Samples](CodeSamples.Java.md)
-+ [\.NET Code Samples](CodeSamples.DotNet.md)
+The code examples in this Developer Guide provide more in\-depth coverage of DynamoDB operations, using the following programming languages:
++ [Java Code Examples](CodeSamples.Java.md)
++ [\.NET Code Examples](CodeSamples.DotNet.md)
 
-Before you can begin with this exercise, you will need to sign up for AWS, get your access key and secret key, and set up the AWS Command Line Interface on your computer\. If you haven't done so, see [Setting Up DynamoDB \(Web Service\)](SettingUp.DynamoWebService.md)\.
+Before you can begin with this exercise, you need to create an AWS account, get your access key and secret key, and set up the AWS Command Line Interface on your computer\. If you haven't done this already, see [Setting Up DynamoDB \(Web Service\)](SettingUp.DynamoWebService.md)\.
 
 **Note**  
-If you are using the downloadable version of DynamoDB, you need to use the AWS CLI to create the tables and sample data\. You also need to specify the `--endpoint-url` parameter with each AWS CLI command\. For more information, see [Setting the Local Endpoint](DynamoDBLocal.Endpoint.md)\.
+If you are using the downloadable version of DynamoDB, you need to use the AWS CLI to create the tables and example data\. You also need to specify the `--endpoint-url` parameter with each AWS CLI command\. For more information, see [Setting the Local Endpoint](DynamoDBLocal.Endpoint.md)\.


### PR DESCRIPTION
Why do we use "code sample" and "code samples" in our documentation when our style guidance says to use "code example" instead of "code sample"? See https://alpha-docs-aws.amazon.com/awsstyleguide/latest/styleguide/dictionary.html#style-code_example, which says about code sample, "Do not use. Use code example instead."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
