### PR TITLE
Different response for describe-table in AWS CLI

### DIFF
--- a/doc_source/getting-started-step-6-CLI.md
+++ b/doc_source/getting-started-step-6-CLI.md
@@ -85,11 +85,11 @@ Note that the value of the `IndexStatus` field is set to `CREATING`\.
 To verify that DynamoDB has finished creating the `AlbumTitle-index` global secondary index, use the `describe-table` command\. 
 
 ```
- aws dynamodb describe-table --table-name Music | grep IndexStatus
+ aws dynamodb describe-table --table-name Music | head -n 1 | cut -f 8
 ```
 
 This command returns the result shown below\. The index is ready for use when the value of the `IndexStatus` field returned is set to `ACTIVE`\. 
 
 ```
-"IndexStatus": "ACTIVE", 
+"ACTIVE" 
 ```


### PR DESCRIPTION
In AWS CLI in linux the describe table is giving different format response than the one given in example. Current response is as of the format given below:

TABLE	xxxxxxxxxx.xxx	1	arn:aws:dynamodb:us-east-1:xxxxxxxxxxxx:table/Music	xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx	Music	68	ACTIVE
ATTRIBUTEDEFINITIONS	Artist	S
ATTRIBUTEDEFINITIONS	SongTitle	S
KEYSCHEMA	Artist	HASH
KEYSCHEMA	SongTitle	RANGE
PROVISIONEDTHROUGHPUT	0	1	1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
