### PR TITLE
fix: fix programming errors documentation

### DIFF
--- a/doc_source/Expressions.ConditionExpressions.md
+++ b/doc_source/Expressions.ConditionExpressions.md
@@ -149,7 +149,7 @@ aws dynamodb update-item \
     --expression-attribute-values file://values.json
 ```
 
-The arguments for `--item` are stored in the file `values.json`:
+The arguments for `--update-expression` and `--condition-expression` are stored in the file `values.json`:
 
 ```
 {

--- a/doc_source/Programming.Errors.md
+++ b/doc_source/Programming.Errors.md
@@ -127,7 +127,7 @@ The AWS SDKs perform their own retries and error checking\. If you encounter an 
 
 You should also see a `Request ID` in the response\. The `Request ID` can be helpful if you need to work with AWS Support to diagnose an issue\.
 
-The following Java code example tries to delete an item from a DynamoDB table and performs rudimentary error handling\. \(In this case, it simply informs the user that the request failed\.\) 
+The following Java code example tries to get an item from a DynamoDB table and performs rudimentary error handling\. \(In this case, it simply informs the user that the request failed\.\) 
 
 ```
 Table table = dynamoDB.getTable("Movies");


### PR DESCRIPTION
*Issue :*
There is a documentation error in the  Programming.Errors.md and Expressions.ConditionExpressions.md

*Description of changes:*
in the 'Error Handling in Your Application' section, the provided example get an item from the 'Movies' table, and not delete an item. But the description says that it is deleting an item from that table.

in the 'Conditional Updates' section, the provided example updates an item using the cli, but there is no use of --item, which is however mentioned in the description.

This PR aim to improve this documentation to make it more accurate, and to omit any confusing for future readers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
