### PR TITLE
Fix decimal encoder for negative decimals

### DIFF
--- a/doc_source/GettingStarted.Python.03.md
+++ b/doc_source/GettingStarted.Python.03.md
@@ -120,7 +120,7 @@ You can use the `get_item` method to read the item from the `Movies` table\. You
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)
@@ -212,7 +212,7 @@ The item is updated as follows\.
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)
@@ -281,7 +281,7 @@ The following program shows how to increment the `rating` for a movie\. Each tim
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)
@@ -346,7 +346,7 @@ In this case, the item is updated only if there are more than three actors\.
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)
@@ -437,7 +437,7 @@ In the following example, you try to delete a specific movie item if its rating 
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)

--- a/doc_source/GettingStarted.Python.04.md
+++ b/doc_source/GettingStarted.Python.04.md
@@ -47,7 +47,7 @@ The program included in this step retrieves all movies released in the `year` 19
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)
@@ -163,7 +163,7 @@ The following program scans the entire `Movies` table, which contains approximat
    class DecimalEncoder(json.JSONEncoder):
        def default(self, o):
            if isinstance(o, decimal.Decimal):
-               if o % 1 > 0:
+               if abs(o) % 1 > 0:
                    return float(o)
                else:
                    return int(o)


### PR DESCRIPTION
Was fixed in
https://github.com/awsdocs/amazon-dynamodb-developer-guide/commit/831c4b5f6864ed4ab9eb61101c351045d813e876#diff-10922191e3e8c92526d4d891a70066f8
but looks like there is now more.

*Issue #, if available:*

*Description of changes:*

Handle negative decimal numbers in DecimalEncoder example


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
