### PR TITLE
Fix TTL python3 expression

### DIFF
--- a/doc_source/time-to-live-ttl-how-to.md
+++ b/doc_source/time-to-live-ttl-how-to.md
@@ -71,6 +71,6 @@ aws dynamodb put-item --table-name "TTLExample" --item '{"id": {"N": "1"}, "ttl"
 
 It is fairly simple to get the current time in epoch time format\. For example:
 + Linux Terminal: `date +%s`
-+ Python: `import time; long(time.time())`
++ Python: `import time; int(time.time())`
 + Java: `System.currentTimeMillis() / 1000L`
 + JavaScript: `Math.floor(Date.now() / 1000)`


### PR DESCRIPTION
*Issue #, if available:* 
As of January 1, 2020, Python2 is getting End of life.
I have updated `ttl` python specific doc to use python3.


*Description of changes:*

*Before*
```
import time; a=long(time.time())
Traceback (most recent call last):
  File "<input>", line 1, in <module>
NameError: name 'long' is not defined
```
*After*
```
import time; a=int(time.time())
1577712222
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
