### PR TITLE
Added a phrase to clarify the LSI limitation

### DIFF
--- a/doc_source/LSI.md
+++ b/doc_source/LSI.md
@@ -31,7 +31,7 @@ However, you can specify one or more local secondary indexes on non\-key attribu
 
 A *local secondary index* maintains an alternate sort key for a given partition key value\. A local secondary index also contains a copy of some or all of the attributes from its base table; you specify which attributes are projected into the local secondary index when you create the table\. The data in a local secondary index is organized by the same partition key as the base table, but with a different sort key\. This lets you access data items efficiently across this different dimension\. For greater query or scan flexibility, you can create up to five local secondary indexes per table\. 
 
-Suppose that an application needs to find all of the threads that have been posted within the last three months\. Without a local secondary index, the application would have to `Scan` the entire *Thread* table and discard any posts that were not within the specified time frame\. With a local secondary index, a `Query` operation could use *LastPostDateTime* as a sort key and find the data quickly\.
+Suppose that an application needs to find all of the threads that have been posted within the last three months in a particular forum\. Without a local secondary index, the application would have to `Scan` the entire *Thread* table and discard any posts that were not within the specified time frame\. With a local secondary index, a `Query` operation could use *LastPostDateTime* as a sort key and find the data quickly\.
 
 The following diagram shows a local secondary index named *LastPostIndex*\. Note that the partition key is the same as that of the *Thread* table, but the sort key is *LastPostDateTime*\.
 


### PR DESCRIPTION
*Issue #, if available:* Misleading statement 

*Description of changes:*

The statement: _"Suppose that an application needs to find all of the threads that have been posted within the last three months" is a little misleading. It should mention the phrase: "in a particular forum"_ since an LSI is not used to "find **all** of the threads/items" on a given table but only on a **certain** partition key only (which is the ForumName, that signifies a particular forum)

This will also be in-line with the question in the above paragraph:
"How many threads were posted in a particular forum **within a particular time period?**"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
