### PR TITLE
Shouldn't this be query cache?

### DIFF
--- a/doc_source/DAX.concepts.md
+++ b/doc_source/DAX.concepts.md
@@ -68,7 +68,7 @@ DAX also maintains a least recently used list \(LRU\) for the item cache\. The L
 
 DAX also maintains a *query cache* to store the results from `Query` and `Scan` operations\. The items in this cache represent result sets from queries and scans on DynamoDB tables\. These result sets are stored by their parameter values\.
 
-When an application sends a `Query` or `Scan` request, DAX attempts to read a matching result set from the query cache using the specified parameter values\. If the result set is found \(cache hit\), DAX returns it to the application immediately\. If the result set is not found \(cache miss\), DAX sends the request to DynamoDB\. DynamoDB processes the requests using eventually consistent reads, and returns the result set to DAX\. DAX stores it in the item cache, and then returns it to the application\.
+When an application sends a `Query` or `Scan` request, DAX attempts to read a matching result set from the query cache using the specified parameter values\. If the result set is found \(cache hit\), DAX returns it to the application immediately\. If the result set is not found \(cache miss\), DAX sends the request to DynamoDB\. DynamoDB processes the requests using eventually consistent reads, and returns the result set to DAX\. DAX stores it in the query cache, and then returns it to the application\.
 
 **Note**  
 You can specify the TTL setting for the query cache when you create a new DAX cluster\. For more information, see [Managing DAX Clusters](DAX.cluster-management.md)\.\)


### PR DESCRIPTION
*Description of changes:* I was going through the cache and found inconsistency. Is it the expected behavior for items to land in items cache after a query operation cache miss?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
