### PR TITLE
Fix incorrect JSON portion in time-to-live-ttl-streams.md

### DIFF
--- a/doc_source/time-to-live-ttl-streams.md
+++ b/doc_source/time-to-live-ttl-streams.md
@@ -26,7 +26,10 @@ The following JSON shows the relevant portion of a single Streams record\.
 
         ...
 
-    ]}
+    }
+    
+    ...
+]
 ```
 
 Items deleted by other users will show the `principalId` of the account used to delete the items\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The order of last ] and } in the JSON example should be swapped. This pull request fixes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
