### PR TITLE
Update bp-gsi-aggregation.md

### DIFF
--- a/doc_source/bp-gsi-aggregation.md
+++ b/doc_source/bp-gsi-aggregation.md
@@ -6,7 +6,7 @@ Consider the following music library table layout:
 
 ![\[Music library table layout example.\]](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/images/AggregationQueries.png)
 
-The table in this example stores songs with the `songID` as the partition key\. You can enable Amazon DynamoDB Streams on this table and attach a Lambda function to the streams so that as each song is downloaded, an entry is added to the table with `Partition-Key=SongID` and `Sort-Key=DownloadID`\. As these updates are made, they trigger a Lambda function in DynamoDB Streams\. The Lambda function can aggregate and group the downloads by `songID` and update the top\-level item, `Partition-Key=songID`, and `Sort-Key=Month`\.
+The table in this example stores songs with the `songID` as the partition key\. You can enable Amazon DynamoDB Streams on this table and attach a Lambda function to the streams so that as each song is downloaded, an entry is added to the table with `Partition-Key=SongID` and `Sort-Key=DownloadID`\. As these updates are made, they trigger a Lambda function in DynamoDB Streams\. The Lambda function can aggregate and group the downloads by `songID` and update the top\-level item, `Partition-Key=songID`, and `Sort-Key=Month`\. But keep in mind that due to failures in the Lambda, some values might be aggregated more than once, leaving you with approximate value.
 
 To read the updates in near real time, with single\-digit millisecond latency, use the global secondary index with query conditions `Month=2018-01`, `ScanIndexForward=False`, `Limit=1`\.
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

We need to make sure the customers are aware the this approach does not guarantee idempotency.

If a lambda execution fails just after writing the new aggregated value, it might be retried and add a duplicated value into the aggregation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
