### PR TITLE
Link to the current version's best practices

### DIFF
--- a/doc_source/bp-global-tables.md
+++ b/doc_source/bp-global-tables.md
@@ -1,3 +1,3 @@
 # Best Practices for Using Global Tables<a name="bp-global-tables"></a>
 
- There are several requirements and best practices that you must consider when using global tables\. For more information, see [Best Practices and Requirements for Managing Global Tables](globaltables_reqs_bestpractices.md)\. 
+ There are several requirements and best practices that you must consider when using global tables\. For more information, see [Best Practices and Requirements for Managing Global Tables](V2globaltables_reqs_bestpractices.md)\. 


### PR DESCRIPTION
Currently, this link goes to the best practices for global tables Version 2017.11.29, but the current version of global tables is Version 2019.11.21. As Version 2019.11.21 is more recent, and contains meaningful improvements over Version 2017.11.29, the documentation should link to it instead of Version 2017.11.29.

*Issue #, if available:*
N/A

*Description of changes:*
 - Updates outdated link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
