### PR TITLE
use consistent terminology for describing capacity

### DIFF
--- a/doc_source/Query.md
+++ b/doc_source/Query.md
@@ -159,7 +159,7 @@ You can `Query` any table or secondary index, provided that it has a composite p
 | --- | --- | 
 | Table | The table's provisioned read capacity\. | 
 | Global secondary index | The index's provisioned read capacity\. | 
-| Local secondary index | The base table's provisioned read capacity\. | 
+| Local secondary index | The table's provisioned read capacity\. | 
 
 By default, a `Query` operation does not return any data on how much read capacity it consumes\. However, you can specify the `ReturnConsumedCapacity` parameter in a `Query` request to obtain this information\. The following are the valid settings for `ReturnConsumedCapacity`:
 + `NONE` — No consumed capacity data is returned\. \(This is the default\.\)


### PR DESCRIPTION
It seems odd to say "the base table's" two lines after saying "the table's". By adding the word "base", it seems to imply that this is somehow different than the table's capacity. To the best of my knowledge, there is no difference - you're using capacity that comes from the table's provisioning (if it's a provisioned capacity table).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
