### PR TITLE
Added a note on native backup and restore feature

### DIFF
--- a/doc_source/DynamoDBPipeline.md
+++ b/doc_source/DynamoDBPipeline.md
@@ -1,3 +1,6 @@
+**Important**   
+DynamoDB Backup and Restore is a fully managed feature. You can back up tables from a few megabytes to hundreds of terabytes of data, with no impact on performance and availability to your production applications. You can restore your table with a single click in the AWS Management Console or a single API call. It is highly recommended to use native backup and restore feature of DynamoDB instead of using AWS Data Pipeline. For more information see [On-Demand Backup and Restore for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/BackupRestore.html).
+
 # Exporting and Importing DynamoDB Data Using AWS Data Pipeline<a name="DynamoDBPipeline"></a>
 
 You can use AWS Data Pipeline to export data from a DynamoDB table to a file in an Amazon S3 bucket\. You can also use the console to import data from Amazon S3 into a DynamoDB table, in the same AWS region or in a different region\.


### PR DESCRIPTION
The native Backup and restore feature of DynamoDB is easy and efficient than using AWS Data Pipeline. As of now (Aug, 2020) the only reason, we should use Data Pipeline is when we want to restore table in a different AWS account. 
Data pipeline consumes read capacity from the base table which might impact a production table and you need to do additional capacity planning for EMR data nodes for this solution.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
