### PR TITLE
Add link to 'Working with Items' for more info

### DIFF
--- a/doc_source/Expressions.ConditionExpressions.md
+++ b/doc_source/Expressions.ConditionExpressions.md
@@ -22,6 +22,10 @@ The arguments for `--item` are stored in the `item.json` file\. \(For simplicity
 }
 ```
 
+**Note**  
+To learn more about how Conditional Write works, its idempotency model, and how it consumes Capacity Units, also check the **Conditional Writes** section in [Working with Items](WorkingWithItems.html) page.
+
+
 **Topics**
 + [Conditional Put](#Expressions.ConditionExpressions.PreventingOverwrites)
 + [Conditional Deletes](#Expressions.ConditionExpressions.AdvancedComparisons)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* following this [StackoverFlow question](https://stackoverflow.com/questions/65188184/does-aws-dynamodb-consume-throuput-or-charges-for-a-put-item-write-operation-t), I'm adding a link to "Working with Items", which lays out more details about how Conditional Writes work. Currently, by reading the "Conditional Writes" page, one may assume that's everything there is to read about the topic in the docs. Turns out this isn't true, there's relevant more information in another page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
