### PR TITLE
Fix the table name

### DIFF
--- a/doc_source/PointInTimeRecovery.Tutorial.md
+++ b/doc_source/PointInTimeRecovery.Tutorial.md
@@ -35,7 +35,7 @@ You can restore the table to the same AWS Region or to a different Region from w
 **Note**  
 You can restore to any point in time within **Earliest restore date** and **Latest restore date**\. DynamoDB restores your table data to the state based on the selected date and time \(`day:hour:minute:second`\)\.
 
-   The table that is being restored is shown with the status **Restoring**\. After the restore process is finished, the status of the `Music` table changes to **Active**\.
+   The table that is being restored is shown with the status **Restoring**\. After the restore process is finished, the status of the `MusicMinutesAgo` table changes to **Active**\.
 
 ## Restoring a Table to a Point in Time \(AWS CLI\)<a name="restorepointintime_cli"></a>
 


### PR DESCRIPTION
It seems like the target table name is switched to active once the restore is complete, the source table always remains active.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
