### PR TITLE
Fix syntax of DELETE example

### DIFF
--- a/doc_source/SQLtoNoSQL.DeleteData.md
+++ b/doc_source/SQLtoNoSQL.DeleteData.md
@@ -32,8 +32,8 @@ In DynamoDB, you use the `DeleteItem` action to delete data from a table, one it
 {
     TableName: "Music",
     Key: {
-        Artist: "The Acme Band",
-        SongTitle: "Look Out, World"
+        Artist: { S: "The Acme Band" },
+        SongTitle: { S: "Look Out, World" }
     }
 }
 ```
@@ -47,8 +47,8 @@ In addition to `DeleteItem`, Amazon DynamoDB supports a `BatchWriteItem` action 
 {
     TableName: "Music",
     Key: {
-        Artist: "The Acme Band",
-        SongTitle: "Look Out, World"
+        Artist: { S: "The Acme Band" },
+        SongTitle: { S: "Look Out, World" }
     },
    ConditionExpression: "attribute_exists(RecordLabel)"
 }


### PR DESCRIPTION
Update DELETE documentation with working syntax.

*Description of changes:*

When I ran this example it failed. However, putting `{ S: "string" }` here makes this example work.