### PR TITLE
Code sample does not work for boto3 version 1.17.77 and amazondax 1.1.8

### DIFF
--- a/doc_source/DAX.client.run-application-python.03-getitem-test.md
+++ b/doc_source/DAX.client.run-application-python.03-getitem-test.md
@@ -45,7 +45,12 @@ if __name__ == '__main__':
     parser.add_argument(
         'endpoint_url', nargs='?',
         help="When specified, the DAX cluster endpoint. Otherwise, DAX is not used.")
+    parser.add_argument(
+        'region', nargs='?',
+        help="The DAX cluster region.")
     args = parser.parse_args()
+    if 'endpoint_url' in vars(args) and 'region' not in vars(args):
+        parser.error('The -endpoint_url argument requires the -region argument')
 
     test_key_count = 10
     test_iterations = 50
@@ -53,7 +58,7 @@ if __name__ == '__main__':
         print(f"Getting each item from the table {test_iterations} times, "
               f"using the DAX client.")
         # Use a with statement so the DAX client closes the cluster after completion.
-        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url) as dax:
+        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url, region_name=args.region) as dax:
             test_start, test_end = get_item_test(
                 test_key_count, test_iterations, dyn_resource=dax)
     else:

--- a/doc_source/DAX.client.run-application-python.03-getitem-test.md
+++ b/doc_source/DAX.client.run-application-python.03-getitem-test.md
@@ -58,7 +58,8 @@ if __name__ == '__main__':
         print(f"Getting each item from the table {test_iterations} times, "
               f"using the DAX client.")
         # Use a with statement so the DAX client closes the cluster after completion.
-        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url, region_name=args.region) as dax:
+        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url, 
+                                                region_name=args.region) as dax:
             test_start, test_end = get_item_test(
                 test_key_count, test_iterations, dyn_resource=dax)
     else:

--- a/doc_source/DAX.client.run-application-python.04-query-test.md
+++ b/doc_source/DAX.client.run-application-python.04-query-test.md
@@ -48,7 +48,12 @@ if __name__ == '__main__':
     parser.add_argument(
         'endpoint_url', nargs='?',
         help="When specified, the DAX cluster endpoint. Otherwise, DAX is not used.")
+    parser.add_argument(
+        'region', nargs='?',
+        help="The DAX cluster region.")
     args = parser.parse_args()
+    if 'endpoint_url' in vars(args) and 'region' not in vars(args):
+        parser.error('The -endpoint_url argument requires the -region argument')
 
     test_partition_key = 5
     test_sort_keys = (2, 9)
@@ -56,7 +61,8 @@ if __name__ == '__main__':
     if args.endpoint_url:
         print(f"Querying the table {test_iterations} times, using the DAX client.")
         # Use a with statement so the DAX client closes the cluster after completion.
-        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url) as dax:
+        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url, 
+                                                region_name=args.region) as dax:
             test_start, test_end = query_test(
                 test_partition_key, test_sort_keys, test_iterations, dyn_resource=dax)
     else:

--- a/doc_source/DAX.client.run-application-python.05-scan-test.md
+++ b/doc_source/DAX.client.run-application-python.05-scan-test.md
@@ -39,13 +39,19 @@ if __name__ == '__main__':
     parser.add_argument(
         'endpoint_url', nargs='?',
         help="When specified, the DAX cluster endpoint. Otherwise, DAX is not used.")
+    parser.add_argument(
+        'region', nargs='?',
+        help="The DAX cluster region.")
     args = parser.parse_args()
+    if 'endpoint_url' in vars(args) and 'region' not in vars(args):
+        parser.error('The -endpoint_url argument requires the -region argument')
 
     test_iterations = 100
     if args.endpoint_url:
         print(f"Scanning the table {test_iterations} times, using the DAX client.")
         # Use a with statement so the DAX client closes the cluster after completion.
-        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url) as dax:
+        with amazondax.AmazonDaxClient.resource(endpoint_url=args.endpoint_url, 
+                                                region_name=args.region) as dax:
             test_start, test_end = scan_test(test_iterations, dyn_resource=dax)
     else:
         print(f"Scanning the table {test_iterations} times, using the Boto3 client.")


### PR DESCRIPTION
The code samples were not working for a combination of libraries (on Python 3.6); boto3 version 1.17.77 and amazondax 1.1.8.  `region_name` needs to be specified when creating the DAX resource.

*Issue #, if available:*
I did not create an issue, but there is a closed AWS support ticket for it: Case ID 8363559221. 

*Description of changes:*
The main change is to add 'region_name' to the DAX resource initialization. To this end an extra argument had to be added (with proper error handling). This change was made in 3 files affected by this. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
