### PR TITLE
Minor updates to example query

### DIFF
--- a/doc_source/ql-reference.multiplestatements.transactions.md
+++ b/doc_source/ql-reference.multiplestatements.transactions.md
@@ -56,14 +56,14 @@ If any of the singleton INSERT, UPDATE, or DELETE operations return an error, th
    ```
    [
        {
-           "Statement": "EXISTS(SELECT * FROM Music where Artist='No One You Know' and SongTitle='Call Me Today' and Awards is  MISSING)"
+           "Statement": "EXISTS(SELECT * FROM Music WHERE Artist='No One You Know' AND SongTitle='Call Me Today' AND Awards IS MISSING)"
        },
        {
-           "Statement": "INSERT INTO Music value {'Artist':'?','SongTitle':'?'}",
+           "Statement": "INSERT INTO Music value {'Artist':?,'SongTitle':?}",
            "Parameters": [{"S": "Acme Band"}, {"S": "Best Song"}]
        },
        {
-           "Statement": "UPDATE Music SET AwardsWon=1 SET AwardDetail={'Grammys':[2020, 2018]}  where Artist='Acme Band' and SongTitle='PartiQL Rocks'"
+           "Statement": "UPDATE Music SET AwardsWon=1 SET AwardDetail={'Grammys':[2020, 2018]} WHERE Artist='Acme Band' AND SongTitle='PartiQL Rocks'"
        }
    ]
    ```


### PR DESCRIPTION
- removed the single quotes around param placeholder. From my tests (on DDB Local at least), '?' will insert the actual ' chars, which 99.9% of time is not what you want.
- removed redundant spaces 
- proper capitalization of PartiQL keywords for consistency

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
