### PR TITLE
Added table-name param for Querying GSI

### DIFF
--- a/doc_source/GCICli.md
+++ b/doc_source/GCICli.md
@@ -81,6 +81,7 @@ The only attributes returned are those that have been projected into the index\.
 
 ```
 aws dynamodb query \
+    --table-name GameScores \
     --index-name GameTitleIndex \
     --key-condition-expression "GameTitle = :v_game" \
     --expression-attribute-values '{":v_game":{"S":"Alien Adventure"} }'


### PR DESCRIPTION
*Description of changes:*
Section on Querying a Global Secondary Index was missing the --table-name parameter for the CLI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
