### PR TITLE
Fixing documentation of Atomic counter

### DIFF
--- a/doc_source/LowLevelDotNetItemCRUD.md
+++ b/doc_source/LowLevelDotNetItemCRUD.md
@@ -274,7 +274,7 @@ For more information, see [UpdateItem](https://docs.aws.amazon.com/amazondynamod
 
 ## Atomic Counter<a name="AtomicCounterLowLevelDotNet"></a>
 
-You can use `updateItem` to implement an atomic counter, where you increment or decrement the value of an existing attribute without interfering with other write requests\. To update an atomic counter, use `updateItem` with an attribute of type `Number` in the `UpdateExpression` parameter, and `ADD` as the `Action`\.
+You can use `updateItem` to implement an atomic counter, where you increment or decrement the value of an existing attribute without interfering with other write requests\. To update an atomic counter, use `updateItem` with an attribute of type `Number` in the `UpdateExpression` parameter, and `SET` as the `Action`\.
 
 The following example demonstrates this, incrementing the `Quantity` attribute by one\.
 


### PR DESCRIPTION
The description indicated one should use the `ADD` action, but the code sample uses the `SET` action. Correcting the documentation to use `SET` in both places.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
