### PR TITLE
Added a batch limit note.

### DIFF
--- a/doc_source/ql-reference.multiplestatements.batching.md
+++ b/doc_source/ql-reference.multiplestatements.batching.md
@@ -4,6 +4,7 @@ This section describes how to use batch statements with PartiQL for DynamoDB\.
 
 **Note**  
 The entire batch must consist of either read statements or write statements; you cannot mix both in one batch\.
+The batch must have 1 statement and no more than 25 statements\.
 
 **Topics**
 + [Syntax](#ql-reference.multiplestatements.batching.syntax)


### PR DESCRIPTION
This call appears to be limited to 25 statements as defined in the [BatchExecuteStatement API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchExecuteStatement.html).

*Issue #, if available:*

*Description of changes:*

Added a note about the 25 statement limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
