### PR TITLE
Precise that dates can be compared

### DIFF
--- a/doc_source/HowItWorks.NamingRulesDataTypes.md
+++ b/doc_source/HowItWorks.NamingRulesDataTypes.md
@@ -83,6 +83,8 @@ You can use the string data type to represent a date or a timestamp\. One way to
 
 For more information, see [http://en\.wikipedia\.org/wiki/ISO\_8601](http://en.wikipedia.org/wiki/ISO_8601)\.
 
+Provided this format is used, comparison operators, such as RANGE or BETWEEN, are available for date.
+
 #### Binary<a name="HowItWorks.DataTypes.Binary"></a>
 
 Binary type attributes can store any binary data, such as compressed text, encrypted data, or images\. Whenever DynamoDB compares binary values, it treats each byte of the binary data as unsigned\.


### PR DESCRIPTION
*Issue #, if available:*
No mention of possible comparison operations based on dates.

*Description of changes:*
Add a mention of such a possible, when ISO-8601 are used. 
cf. https://stackoverflow.com/questions/40561484/what-data-type-should-be-used-for-timestamp-in-dynamodb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
