### PR TITLE
reference current image amazon/awscli

### DIFF
--- a/doc_source/DynamoDBLocal.DownloadingAndRunning.md
+++ b/doc_source/DynamoDBLocal.DownloadingAndRunning.md
@@ -92,7 +92,7 @@ If you want to run a multi\-container application that also uses the DynamoDB lo
      app-node:
        depends_on:
          - dynamodb-local
-       image: banst/awscli
+       image: amazon/awscli
        container_name: app-node
        ports:
         - "8080:8080"


### PR DESCRIPTION
instead of deprecated image banst/awscli

*Issue #, if available:* 
No issue as I believe the change is small

*Description of changes:* 
change from banst/awscli to amazon/awscli


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
