### PR TITLE
Add PendingReplicationCount isn't in GT 2019

### DIFF
--- a/doc_source/globaltables_monitoring.md
+++ b/doc_source/globaltables_monitoring.md
@@ -18,5 +18,7 @@ You can use Amazon CloudWatch to monitor the behavior and performance of a globa
   During normal operation, `PendingReplicationCount` should be very low\. If `PendingReplicationCount` increases for extended periods, investigate whether your replica tables' provisioned write capacity settings are sufficient for your current workload\.
 
   `PendingReplicationCount` can increase if an AWS Region becomes degraded and you have a replica table in that Region\. In this case, you can temporarily redirect your application's read and write activity to a different AWS Region\.
+  
+  `PendingReplicationCount` is only available with [Version 2017\.11\.29](globaltables.V1.md)\.
 
  For more information, see [DynamoDB Metrics and Dimensions](metrics-dimensions.md)\. 


### PR DESCRIPTION
The PendingReplicationCount metric was removed with GTv2 (2019). Yes this specific page is placed in the 2017 section of the guide but that's kinda subtle and when you find this page via Googling you assume it's generally valid. Perhaps the doc title should also put "(version 2017)" in it.

*Issue #, if available:*

*Description of changes:*
PendingReplicationCount isn't in GTv2 (2019). The docs should note this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
