### PR TITLE
Trailing whitespace causing multiline command to fail

### DIFF
--- a/doc_source/getting-started-step-1.md
+++ b/doc_source/getting-started-step-1.md
@@ -114,9 +114,9 @@ This command returns the following result\. When DynamoDB finishes creating the 
 Once the table is in `ACTIVE` status, it's considered best practice to enable [Point\-in\-time recovery for DynamoDB](PointInTimeRecovery.md) on the table by running the following command:
 
 ```
-aws dynamodb update-continuous-backups \ 
-    --table-name Music \ 
-    --point-in-time-recovery-specification \ 
+aws dynamodb update-continuous-backups \
+    --table-name Music \
+    --point-in-time-recovery-specification \
         PointInTimeRecoveryEnabled=true
 ```
 


### PR DESCRIPTION
As mentioned in title, there was a whitespace after the backslash. Could think about adding this to lints in an automated process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
